### PR TITLE
Allow different criteria to select genes

### DIFF
--- a/tangram/mapping_utils.py
+++ b/tangram/mapping_utils.py
@@ -19,7 +19,7 @@ from . import utils as ut
 logging.getLogger().setLevel(logging.INFO)
 
 
-def pp_adatas(adata_sc, adata_sp, genes=None, gene_to_lowercase = True):
+def pp_adatas(adata_sc, adata_sp, genes=None, gene_to_lowercase = True, min_cells=1):
     """
     Pre-process AnnDatas so that they can be mapped. Specifically:
     - Remove genes that all entries are zero
@@ -37,8 +37,8 @@ def pp_adatas(adata_sc, adata_sp, genes=None, gene_to_lowercase = True):
     """
 
     # remove all-zero-valued genes
-    sc.pp.filter_genes(adata_sc, min_cells=1)
-    sc.pp.filter_genes(adata_sp, min_cells=1)
+    sc.pp.filter_genes(adata_sc, min_cells=min_cells)
+    sc.pp.filter_genes(adata_sp, min_cells=min_cells)
 
     if genes is None:
         # Use all genes

--- a/tangram/utils.py
+++ b/tangram/utils.py
@@ -338,7 +338,7 @@ def deconvolve_cell_annotations(adata_sp, filter_cell_annotation=None):
     return adata_segment
 
 
-def project_genes(adata_map, adata_sc, cluster_label=None, scale=True):
+def project_genes(adata_map, adata_sc, cluster_label=None, scale=True, min_cells=1):
     """
     Transfer gene expression from the single cell onto space.
 
@@ -359,7 +359,7 @@ def project_genes(adata_map, adata_sc, cluster_label=None, scale=True):
     adata_sc.var_names_make_unique()
 
     # remove all-zero-valued genes
-    sc.pp.filter_genes(adata_sc, min_cells=1)
+    sc.pp.filter_genes(adata_sc, min_cells=min_cells)
 
     if cluster_label:
         adata_sc = mu.adata_to_cluster_expression(adata_sc, cluster_label, scale=scale)


### PR DESCRIPTION
Hi, I notice that the original codes forcely filter the genes without expression in cells, I think it will cause problems when we intend to impute non-expressed genes in the single-cell data but might exist in the spatial data, and different tasks also require different gene conditions. Therefore, I suggest adding the min_cell as a optional argument.